### PR TITLE
fix: corrected openAI model name

### DIFF
--- a/templates/next/config/agent.ts
+++ b/templates/next/config/agent.ts
@@ -10,7 +10,7 @@ import { ChatDeepSeek } from "@langchain/deepseek";
 export async function initializeAgent(modelName: string) {
   const llm = modelName?.includes("OpenAI") 
     ? new ChatOpenAI({
-        modelName: "gpt-4o-turbo",
+        modelName: "gpt-4o-mini",
         temperature: 0.3,
         apiKey: process.env.OPENAI_API_KEY!,
       })


### PR DESCRIPTION
changed the open ai model name from "gpt-4o-turbo" to "gpt-4o-mini"
gpt-4o-turbo is a wrong name

@thearyanag @arihantbansal 